### PR TITLE
Include <functional> in Demangle.h

### DIFF
--- a/Sources/CSwiftDemangle/PrivateHeaders/include/swift/Demangling/Demangle.h
+++ b/Sources/CSwiftDemangle/PrivateHeaders/include/swift/Demangling/Demangle.h
@@ -23,6 +23,7 @@
 #include <string>
 #include <cassert>
 #include <cstdint>
+#include <functional>
 #define LLVM_DISABLE_ABI_BREAKING_CHECKS_ENFORCING 1
 #include "llvm/ADT/StringRef.h"
 // #include "swift/Runtime/Config.h"


### PR DESCRIPTION
This resolves a build error when using Bazel to build on Xcode 15.3

```
In file included from external/swift-index-store~/Sources/CSwiftDemangle/CSwiftDemangle.cpp:1:
external/swift-index-store~/Sources/CSwiftDemangle/PrivateHeaders/include/swift/Demangling/Demangle.h:61:8: error: no template named 'function' in namespace 'std'
  std::function<std::string(uint64_t, uint64_t)> GenericParameterName =
  ~~~~~^
1 error generated.
Error in child process '/usr/bin/xcrun'. 1
```