### PR TITLE
Add support for rules_swift 3.x and rules_apple 4.x

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -6,8 +6,8 @@ module(
 
 bazel_dep(name = "apple_support", version = "1.16.0")
 bazel_dep(name = "platforms", version = "0.0.9")
-bazel_dep(name = "rules_apple", version = "3.6.0", repo_name = "build_bazel_rules_apple")
-bazel_dep(name = "rules_swift", version = "2.1.1", repo_name = "build_bazel_rules_swift")
+bazel_dep(name = "rules_apple", version = "3.6.0", repo_name = "build_bazel_rules_apple", max_compatibility_level = 4)
+bazel_dep(name = "rules_swift", version = "2.1.1", repo_name = "build_bazel_rules_swift", max_compatibility_level = 3)
 
 non_module_deps = use_extension("//:repositories.bzl", "bzlmod_deps")
 use_repo(non_module_deps, "StaticIndexStore")


### PR DESCRIPTION
By setting `max_compatibility_level` to the next major versions.
