### PR TITLE
Fix Linux SwiftPM library lookup under shimmed PATH

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,22 @@ jobs:
       - run: swift build
       - run: swift test
 
+  test-swiftpm-linux-shimmed-path:
+    runs-on: ubuntu-latest
+    container: swift:6.3
+    env:
+      CC: clang
+    steps:
+      - uses: actions/checkout@v4
+      - shell: bash
+        run: |
+          real_swiftc="$(command -v swiftc)"
+          mkdir -p .ci-bin
+          printf '%s\n' '#!/usr/bin/env bash' "exec \"${real_swiftc}\" \"\$@\"" > .ci-bin/swiftc
+          chmod +x .ci-bin/swiftc
+          PATH="$PWD/.ci-bin:$PATH" swift build
+          PATH="$PWD/.ci-bin:$PATH" swift test
+
   test-linux:
     runs-on: ubuntu-latest
     container: swift:6.3

--- a/Package.swift
+++ b/Package.swift
@@ -26,26 +26,76 @@ let swiftDemangleLinkerSettings: [LinkerSetting] = [
 ]
 
 #else
-let process = Process()
-process.executableURL = URL(fileURLWithPath: "/usr/bin/which")
-process.arguments = ["swiftc"]
-let swiftcPipe = Pipe()
-process.standardOutput = swiftcPipe
-try process.run()
-process.waitUntilExit()
-let swiftcData = swiftcPipe.fileHandleForReading.readDataToEndOfFile()
-let swiftcBin = String(decoding: swiftcData, as: UTF8.self).trimmingCharacters(in: .newlines)
-let toolchainLibDir = URL(fileURLWithPath: swiftcBin).resolvingSymlinksInPath()
-    .deletingLastPathComponent().deletingLastPathComponent().appendingPathComponent("lib").path
+func runProcess(_ executableURL: URL, arguments: [String]) throws -> Data {
+    let process = Process()
+    process.executableURL = executableURL
+    process.arguments = arguments
+
+    let stdout = Pipe()
+    process.standardOutput = stdout
+
+    try process.run()
+    process.waitUntilExit()
+
+    guard process.terminationStatus == 0 else {
+        throw NSError(
+            domain: "swift-index-store.Package",
+            code: Int(process.terminationStatus),
+            userInfo: [
+                NSLocalizedDescriptionKey: "\(arguments.joined(separator: " ")) exited with status \(process.terminationStatus)",
+            ]
+        )
+    }
+
+    return stdout.fileHandleForReading.readDataToEndOfFile()
+}
+
+func linuxToolchainLibraryDirectory(containing library: String) throws -> String {
+    let targetInfoData = try runProcess(
+        URL(fileURLWithPath: "/usr/bin/env"),
+        arguments: ["swiftc", "-print-target-info"]
+    )
+    let targetInfo = try JSONSerialization.jsonObject(with: targetInfoData) as? [String: Any]
+    let paths = targetInfo?["paths"] as? [String: Any]
+
+    var candidateDirectories: [String] = (paths?["runtimeLibraryPaths"] as? [String]) ?? []
+
+    if let runtimeResourcePath = paths?["runtimeResourcePath"] as? String {
+        let runtimeResourceURL = URL(fileURLWithPath: runtimeResourcePath).resolvingSymlinksInPath()
+        candidateDirectories.append(runtimeResourceURL.path)
+        candidateDirectories.append(runtimeResourceURL.deletingLastPathComponent().path)
+        candidateDirectories.append(runtimeResourceURL.deletingLastPathComponent().deletingLastPathComponent().path)
+    }
+
+    let fileManager = FileManager.default
+    let uniqueCandidateDirectories = Array(NSOrderedSet(array: candidateDirectories)) as? [String] ?? []
+
+    if let libraryDirectory = uniqueCandidateDirectories.first(where: { directory in
+        fileManager.fileExists(atPath: "\(directory)/\(library)")
+    }) {
+        return libraryDirectory
+    }
+
+    throw NSError(
+        domain: "swift-index-store.Package",
+        code: 1,
+        userInfo: [
+            NSLocalizedDescriptionKey: "Could not locate \(library) from swiftc -print-target-info",
+        ]
+    )
+}
+
+let indexStoreLibDir = try linuxToolchainLibraryDirectory(containing: "libIndexStore.so")
+let swiftDemangleLibDir = try linuxToolchainLibraryDirectory(containing: "libswiftDemangle.so")
 
 let indexLinkerSettings: [LinkerSetting] = [
-    .unsafeFlags(["-L\(toolchainLibDir)"]),
-    .unsafeFlags(["-Xlinker", "-rpath", "-Xlinker", "\(toolchainLibDir)"]),
+    .unsafeFlags(["-L\(indexStoreLibDir)"]),
+    .unsafeFlags(["-Xlinker", "-rpath", "-Xlinker", "\(indexStoreLibDir)"]),
 ]
 
 let swiftDemangleLinkerSettings: [LinkerSetting] = [
-    .unsafeFlags(["-L\(toolchainLibDir)"]),
-    .unsafeFlags(["-Xlinker", "-rpath", "-Xlinker", "\(toolchainLibDir)"]),
+    .unsafeFlags(["-L\(swiftDemangleLibDir)"]),
+    .unsafeFlags(["-Xlinker", "-rpath", "-Xlinker", "\(swiftDemangleLibDir)"]),
     .linkedLibrary("swiftDemangle"),
 ]
 #endif


### PR DESCRIPTION
## Summary
- resolve Linux SwiftPM library search paths from `swiftc -print-target-info` instead of inferring them from the `swiftc` executable path
- search the target info runtime paths and related parent directories for `libIndexStore.so` and `libswiftDemangle.so`
- add a Linux CI job that prepends a shimmed `swiftc` to `PATH` to cover Homebrew-style superenv layouts